### PR TITLE
Add Registry and its implementation

### DIFF
--- a/driver/registry.go
+++ b/driver/registry.go
@@ -1,0 +1,7 @@
+package driver
+
+import "github.com/gorilla/mux"
+
+type Registry interface {
+	RegisterPublicRoutes(public *mux.Router)
+}

--- a/driver/registry_default.go
+++ b/driver/registry_default.go
@@ -1,0 +1,23 @@
+package driver
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/trangmaiq/gotham/selfservice/flow/registration"
+)
+
+var _ Registry = new(RegistryDefault)
+
+// RegistryDefault implements Registry interface
+type RegistryDefault struct {
+	selfserviceRegistrationHandler *registration.Handler
+}
+
+// NewRegistryDefault constructs a new RegistryDefault
+func NewRegistryDefault() *RegistryDefault {
+	return &RegistryDefault{}
+}
+
+// RegisterPublicRoutes registers all route
+func (rd RegistryDefault) RegisterPublicRoutes(public *mux.Router) {
+	rd.RegistrationHandler().RegisterPublicRoutes(public)
+}

--- a/driver/registry_default_registration.go
+++ b/driver/registry_default_registration.go
@@ -1,0 +1,12 @@
+package driver
+
+import "github.com/trangmaiq/gotham/selfservice/flow/registration"
+
+func (rd *RegistryDefault) RegistrationHandler() *registration.Handler {
+	if rd.selfserviceRegistrationHandler == nil {
+		rd.selfserviceRegistrationHandler = registration.NewHandler()
+	}
+
+	return rd.selfserviceRegistrationHandler
+
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/trangmaiq/gotham
 
 go 1.13
 
-require github.com/spf13/cobra v1.0.0
+require (
+	github.com/gorilla/mux v1.8.0
+	github.com/spf13/cobra v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/selfservice/flow/registration/handler.go
+++ b/selfservice/flow/registration/handler.go
@@ -1,0 +1,23 @@
+package registration
+
+import (
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+const (
+	BrowserRegistrationPath = "/self-service/browser/flows/registration"
+)
+
+type Handler struct{}
+
+// NewHandler returns pointer of Handler struct
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+// RegisterPublicRoutes registers all new routes related to registration
+func (h *Handler) RegisterPublicRoutes(public *mux.Router) {
+	public.HandleFunc(BrowserRegistrationPath, func(writer http.ResponseWriter, request *http.Request) {
+	})
+}


### PR DESCRIPTION
### Description
The `Registry` interface is an important piece to help Gotham runnable. This PR introduces `Registry` as well as its implementation to prepare for Gotham's serve command in the future.